### PR TITLE
Fix packaging for ac-php-core

### DIFF
--- a/ac-php-core.el
+++ b/ac-php-core.el
@@ -29,6 +29,8 @@
 ;; More info and **example** at : https://github.com/xcwen/ac-php 
 ;;
 
+;;; Code:
+
 (require 'json)
 (require 's) ;;https://github.com/magnars/s.el
 (require 'f) ;;https://github.com/rejeep/f.el


### PR DESCRIPTION
Without `;;; Code:', Emacs can't generate a correct commentary.