### PR TITLE
Use truename of directory to avoid duplicate caching

### DIFF
--- a/ac-php-core.el
+++ b/ac-php-core.el
@@ -1686,7 +1686,7 @@ Non-nil SILENT will supress extra status info in the minibuffer."
   "DOCSTRING"
   (let (project-root-dir tags-file ) 
     (when (buffer-file-name) 
-      (setq project-root-dir (file-name-directory (buffer-file-name)  ))
+      (setq project-root-dir (file-truename (file-name-directory (buffer-file-name)  )))
     )
 
     (unless project-root-dir
@@ -1699,7 +1699,7 @@ Non-nil SILENT will supress extra status info in the minibuffer."
                      (string= project-root-dir "/")
                      ))
           (setq  last-dir project-root-dir  )
-          (setq project-root-dir  ( file-name-directory (directory-file-name  project-root-dir ) ) )
+          (setq project-root-dir  (file-truename( file-name-directory (directory-file-name  project-root-dir ) ) ))
           (when (string= last-dir project-root-dir  ) 
             (setq project-root-dir "/" )
             )))


### PR DESCRIPTION
If there are symbolic links in the path to the source code, ac-php can see these as two different source trees depending on how the user opened the file from Emacs and so use and rebuild two different caches for the code. This change uses the truename function in an attempt to eliminate this possibility; seems to be working for me.