### PR TITLE
Fix a typo of link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ extended:  Redis, Swoole
 * [tags](#tags)
 * [large php project config](#configue-php-file-search-for-large-project)
 * [disable cscope config](#disable-cscope-config)
-* [FQA](#fqa)
+* [FAQ](#faq)
 
 
 ##  Install


### PR DESCRIPTION
## About

I found a typo in README.md

- incorrect
    - `FQA`
- correct
    - `FAQ`

## Links

- https://github.com/xcwen/ac-php/blob/master/README.md#faq