### PR TITLE
add documention on how to add basic php library with phpstorm-stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,23 @@ for laravel example
 }
 ```
 
+You can also add the standard php library with [phpstorm stubs](https://github.com/JetBrains/phpstorm-stubs).
 
+Assuming you cloned this repo into <code>/usr/local/src/phpstorm-stubs</code> you base configuration will be:
+
+```json
+{
+  "filter": {
+    "php-file-ext-list": [
+      "php"
+    ],
+    "php-path-list": [
+        "/usr/local/src/phpstorm-stubs"
+    ],
+    "php-path-list-without-subdir": []
+  }
+}
+```
 
 
 ### Rebuild Tags


### PR DESCRIPTION
It is usefull information for every user of ac-php.
I don't know if code in the directory <code>common_php/</code> was intented for the same purpose.