### PR TITLE
Allow customize more options

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+commom_php/* linguist-vendored
+phptest/*    linguist-vendored


### PR DESCRIPTION
Allow customize ac options using Emacs' Easy Customization:

- `ac-php-cscope`
- `ac-php-use-cscope-flag`
- `ac-php-auto-update-intval`

Amended documentation and code cleanup.