### PR TITLE
Updated documentation and code cleanup

### DIFF
--- a/.elpaignore
+++ b/.elpaignore
@@ -1,0 +1,11 @@
+.travis.yml
+.ert-runner
+.gitignore
+.gitattributes
+Makefile
+cp_to_elpa.sh
+images
+commom_php
+phptest
+screenshots
+test

--- a/.ert-runner
+++ b/.ert-runner
@@ -1,0 +1,3 @@
+-L .
+--quiet
+--no-win

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.elc
-*/.tags/*
-*/commom_php/.tags/*
+
+/.tags/
+/commom_php/.tags/*
+/.cask/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,79 @@
+# Copyright (C) 2014-2019 jim
+#
+# This file is not part of GNU Emacs.
+#
+# License
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this file; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+language: emacs-lisp
+
+# Cache stable Emacs binaries, packages and Cask
+cache:
+  apt: true
+  timeout: 604800
+  directories:
+    - "$HOME/emacs"
+    # Cache AC PHP dependencies
+    - ".cask/"
+    # Cache Cask bootstrap dependencies
+    - "$HOME/.emacs.d/.cask"
+
+# Allow Emacs snapshot builds to fail and don't wait for it
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EMACS_VERSION=git-snapshot
+
+git:
+  depth: 1
+
+env:
+  matrix:
+    - EMACS_VERSION=24.3
+    - EMACS_VERSION=24.4
+    - EMACS_VERSION=24.5
+    - EMACS_VERSION=25.1
+    - EMACS_VERSION=25.2
+    - EMACS_VERSION=25.3
+    - EMACS_VERSION=26.1
+    - EMACS_VERSION=git-snapshot
+  global:
+    - PATH="$HOME/bin:$HOME/.cask/bin:$HOME/.evm/bin:$PATH"
+
+before_install:
+  # Setup Emacs Version Manager
+  - git clone -q --depth=1 https://github.com/rejeep/evm.git $HOME/.evm
+  - evm config path /tmp
+
+install:
+  # Install Emacs (according to $EMACS_VERSION) and Cask
+  - evm install emacs-$EMACS_VERSION-travis --use --skip
+  - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
+
+before_script:
+  # Configure $EMACS_MAJOR_VERSION
+  - EMACS_MAJOR_VERSION="$(echo $EMACS_VERSION | cut -d '.' -f 1)"
+
+script:
+  - make help
+  - make init
+  # The 'checkdoc-file' present on Emacs >= 25.1
+  # - '[[ "$EMACS_MAJOR_VERSION" = "24" ]] || make checkdoc'
+  - make test
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ git:
 
 env:
   matrix:
-    - EMACS_VERSION=24.3
     - EMACS_VERSION=24.4
     - EMACS_VERSION=24.5
     - EMACS_VERSION=25.1

--- a/Cask
+++ b/Cask
@@ -1,0 +1,37 @@
+;; -*- mode: emacs-lisp -*-
+
+(source gnu)
+(source melpa)
+
+(package "ac-php" "2.0.7" "Auto Completion source for PHP.")
+
+(files "*.el" "ac-php-comm-tags-data.json" "phpctags")
+
+;; ac-php-core.el
+(depends-on "json")
+(depends-on "s" "1")
+(depends-on "f" "0.17.0")
+(depends-on "popup" "0.5.0")
+(depends-on "cl")
+(depends-on "dash" "1")
+(depends-on "eldoc")
+(depends-on "xcscope" "1")
+
+;; ac-php.el
+(depends-on "auto-complete" "1.4.0")
+(depends-on "yasnippet" "0.8.0")
+
+;; helm-ac-php-apropros.el
+(depends-on "pcase")
+(depends-on "helm")
+
+;; company-php.el
+(depends-on "cl-lib")
+(depends-on "company")
+(depends-on "company-template")
+
+(development
+ (depends-on "php-mode" "1")
+ (depends-on "ert-x")
+ (depends-on "ert-runner")
+(depends-on "undercover"))

--- a/Cask
+++ b/Cask
@@ -28,7 +28,6 @@
 ;; company-php.el
 (depends-on "cl-lib")
 (depends-on "company")
-(depends-on "company-template")
 
 (development
  (depends-on "php-mode" "1")

--- a/Cask
+++ b/Cask
@@ -7,6 +7,8 @@
 
 (files "*.el" "ac-php-comm-tags-data.json" "phpctags")
 
+(depends-on "emacs" "24.4")
+
 ;; ac-php-core.el
 (depends-on "json")
 (depends-on "s" "1")

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,104 @@
+# Copyright (C) 2014-2019 jim
+#
+# This file is not part of GNU Emacs.
+#
+# License
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this file; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+SHELL := $(shell which bash)
+ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+EMACS := emacs
+CASK = cask
+EMACSFLAGS ?=
+TESTFLAGS ?= --reporter ert+duration
+PKGDIR := $(shell EMACS=$(EMACS) $(CASK) package-directory)
+
+# File lists
+SRCS = ac-php-core.el ac-php.el company-php.el helm-ac-php-apropros.el
+OBJS = $(SRCS:.el=.elc)
+
+.SILENT: ;               # no need for @
+.ONESHELL: ;             # recipes execute in same shell
+.NOTPARALLEL: ;          # wait for this target to finish
+.EXPORT_ALL_VARIABLES: ; # send all vars to shell
+Makefile: ; # skip prerequisite discovery
+
+# Run make help by default
+.DEFAULT_GOAL = build
+
+# Internal variables
+EMACSBATCH = $(EMACS) -Q --batch -L . $(EMACSFLAGS)
+RUNEMACS =
+
+# Program availability
+HAVE_CASK := $(shell sh -c "command -v $(CASK)")
+ifndef HAVE_CASK
+$(warning "$(CASK) is not available.  Please run make help")
+RUNEMACS = $(EMACSBATCH)
+else
+RUNEMACS = $(CASK) exec $(EMACSBATCH)
+endif
+
+%.elc: %.el $(PKGDIR)
+	$(RUNEMACS) -f batch-byte-compile $<
+
+$(PKGDIR): Cask
+	$(CASK) install
+	touch $(PKGDIR)
+
+# Public targets
+
+.PHONY: .title
+.title:
+	$(info AC PHP $(shell cat $(ROOT_DIR)/$(SRCS) | grep ";; Version:" | awk -F': ' '{print $$2}'))
+	$(info )
+
+.PHONY: init
+init: $(PKGDIR)
+
+.PHONY: checkdoc
+checkdoc:
+	$(EMACSBATCH) --eval '(checkdoc-file "$(SRCS)")'
+
+.PHONY: build
+build: $(OBJS)
+
+.PHONY: test
+test:
+	$(CASK) exec ert-runner $(TESTFLAGS)
+
+.PHONY: clean
+clean:
+	$(CASK) clean-elc
+
+.PHONY: help
+help: .title
+	echo 'Run `make init` first to install and update all local dependencies.'
+	echo ''
+	echo 'Available targets:'
+	echo '  help:     Show this help and exit'
+	echo '  init:     Initialise the project (has to be launched first)'
+	echo '  checkdoc: Checks AC PHP code for errors in documentation'
+	echo '  build:    Byte compile AC PHP package'
+	echo '  test:     Run the non-interactive unit test suite'
+	echo '  clean:    Remove all byte compiled Elisp files'
+	echo ''
+	echo 'Available programs:'
+	echo '  $(CASK): $(if $(HAVE_CASK),yes,no)'
+	echo ''
+	echo 'You need $(CASK) to develop AC PHP.  See http://cask.readthedocs.io/ for more.'
+	echo ''

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ For more see [screenshots][:screenshots:] page.
 
 ## Installation
 
+Known to work with GNU Emacs 24.4 and later. ac-php may work with older versions of GNU Emacs, or with other flavors of GNU Emacs (e.g. XEmacs) but this is not guaranteed. Bug reports for problems related to using ac-php with older versions of Emacs will most like not be addressed.
+
 Prerequisite packages are:
 
 - php-cli

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This repository contains:
 - Currently ships with [Spacemacs][:gh-spacemacs:]
 - Supports of [`auto-complete`][:gh-ac:], [`company-mode`][:gh-company:] and [`helm`][:gh-helm:]
 - Auto Completion for built-in extensions
-  - Pdo
+  - PDO
   - SPL
   - mysqli
   - SQLite3
@@ -58,6 +58,8 @@ This repository contains:
 - Auto Completion for user defined classes
 - Auto Completion for built-in functions
 - Supports of PHPDoc annotations
+
+For more see [screenshots][:screenshots:] page.
 
 ## Installation
 
@@ -248,7 +250,7 @@ public function hello(): \Acme\Services\HelloService
 $hello = hello();
 ```
 
-Note: if a function or a class member has no defined return value then you need to define it using annotation.
+**Note:** if a function or a class member has no defined return value then you need to define it using annotation.
 
 ### Working with tags
 
@@ -404,10 +406,13 @@ phpctags[/home/jim/phptest/testa.php] ERROR:PHPParser: Unexpected token '}' on l
 In this case you'll need to fix an error in `testa.php` and re run `ac-php-remake-tags`.
 
 
+**Note:** You shouldn't download phpctags, ac-php already ships with its own modified version.
+
+
 If you see something like this:
 
 ```
-no find file .ac-php-conf.json dir in path list: /home/jim/phptest/
+ac-php: Unable to resolve project root
 ```
 
 This means you have to create the `.ac-php-conf.json` file in the project root:
@@ -418,13 +423,13 @@ $ touch /path/to/the/project/.ac-php-conf.json
 
 ## FAQ
 
-- **Q: Something went wrong. It seems I followed all the instructions, but auto completion stopped working**
-- **A: Run `M-x ac-php-remake-tags-all`**
+- **Q:** Something went wrong. It seems I followed all the instructions, but auto completion stopped working
+- **A:** Run `M-x ac-php-remake-tags-all`
 
 ---
 
-- **Q: How I can create a reproducible test to create an issue?**
-- **A: Please use [this issue][:issue-example:] as an example**
+- **Q:** How I can create a reproducible test to create an issue?
+- **A:** Please use [this issue][:issue-example:] as an example
 
 ## License
 
@@ -450,3 +455,4 @@ ac-php is open source software licensed under the GNU General Public Licence ver
 [:phpstorm-stubs:]: https://github.com/JetBrains/phpstorm-stubs
 [:issue-example:]: https://github.com/xcwen/ac-php/issues/51
 [:phpctags:]: https://github.com/xcwen/phpctags
+[:screenshots:]: https://github.com/xcwen/ac-php/tree/master/screenshots

--- a/ac-php.el
+++ b/ac-php.el
@@ -52,7 +52,7 @@
 ;;
 ;; Many options available under Help:Customize
 ;; Options specific to ac-php are in
-;;   Convenience/Completion/Auto Complete/AC PHP
+;;   Convenience/Completion/Auto Complete
 ;;
 ;; Bugs: Bug tracking is currently handled using the GitHub issue tracker
 ;; (see URL `https://github.com/xcwen/ac-php/issues')

--- a/ac-php.el
+++ b/ac-php.el
@@ -6,7 +6,7 @@
 ;; Maintainer: jim
 ;; URL: https://github.com/xcwen/ac-php
 ;; Keywords: completion, convenience, intellisense
-;; Package-Requires: ((ac-php-core "1") (auto-complete "1.4.0") (yasnippet "0.8.0"))
+;; Package-Requires: ((emacs "24.4") (ac-php-core "1") (auto-complete "1.4.0") (yasnippet "0.8.0"))
 
 ;; This file is not part of GNU Emacs.
 

--- a/company-php.el
+++ b/company-php.el
@@ -4,7 +4,7 @@
 ;; URL: https://github.com/xcwen/ac-php
 ;; Package-Version: 20171209.2243
 ;; Keywords: completion, convenience, intellisense
-;; Package-Requires: ( (cl-lib "0.5") (ac-php-core "1") (company "0.9")  )
+;; Package-Requires: ((emacs "24.4") (cl-lib "0.5") (ac-php-core "1") (company "0.9"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/helm-ac-php-apropros.el
+++ b/helm-ac-php-apropros.el
@@ -3,7 +3,8 @@
 ;; Copyright (C) 2018  Antoine Brand
 
 ;; Author: Antoine Brand <antoine597@gmail.com>
-;; Keywords: 
+;; Keywords: convenience, helm
+;; Package-Requires: ((emacs "24.4") (helm "1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -53,7 +54,7 @@
      (lambda (k v)
        (when (not (equalp "sys" (aref v 3)))
          (insert
-          (propertize 
+          (propertize
            (pcase (aref v 0)
              ("d" (concat (if (equalp "void" (aref v 4)) "" (aref v 4)) (aref v 1)))
              ("f" (concat (if (equalp "void" (aref v 4)) "" (aref v 4)) (substring (aref v 1) 0 (- (string-width (aref v 1)) 1))))

--- a/test/ac-php-test.el
+++ b/test/ac-php-test.el
@@ -1,10 +1,12 @@
-;;; ac-php-test.el --- Tests for ac-php
+;;; ac-php-test.el --- AC PHP: Base test -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2013 Daniel Hackney
-;;               2014, 2015 Eric James Michael Ritz
+;; Copyright (C) 2014-2019 jim
 
-;; Author: Daniel Hackney <dan@haxney.org>
-;; URL: https://github.com/ejmr/ac-php
+;; Author: jim <xcwenn@qq.com>
+;; Maintainer: jim
+;; URL: https://github.com/xcwen/ac-php
+
+;; This file is not part of GNU Emacs.
 
 ;;; License
 
@@ -25,20 +27,16 @@
 
 ;;; Commentary:
 
-;; Automate tests from the "tests" directory using `ert', which comes bundled
+;;   Automate tests from the "test" directory using `ert', which comes bundled
 ;; with Emacs >= 24.1.
 
 ;;; Code:
-(require 'package)
-(package-initialize)
 
 (require 'f)
 
-(setq load-path (append  (list (f-parent(f-parent load-file-name))) load-path ) )
-;;(message "load-path %S" load-path )
+(setq load-path (append (list (f-parent(f-parent load-file-name))) load-path))
 
 (require 'ac-php)
-(require 'ert)
 (eval-when-compile
   (require 'cl))
 
@@ -203,7 +201,7 @@ run with specific customizations set."
     (ac-php-test--parse-line line-txt ret  )
     ))
 
- 
+
 
 (ert-deftest ac-php-test-parse-line-11 ()
   (let (line-txt  ret )
@@ -310,6 +308,5 @@ run with specific customizations set."
 
 ;;; ac-php-test.el ends here
 
-;; emacs --debug-init -Q --script ./php-mode-test.el 
+;; emacs --debug-init -Q --script ./php-mode-test.el
 ;; End:
-

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,0 +1,57 @@
+;;; test-helper.el --- BNF Mode: Non-interactive unit-test setup -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2014-2019 jim
+
+;; Author: jim <xcwenn@qq.com>
+;; Maintainer: jim
+;; URL: https://github.com/xcwen/ac-php
+
+;; This file is not part of GNU Emacs.
+
+;;; License
+
+;; This file is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this file; if not, write to the Free Software
+;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+;; 02110-1301, USA.
+
+;;; Commentary:
+
+;; Non-interactive test suite setup for ERT Runner.
+
+;;; Code:
+
+(require 'ert-x)  ; `ert-with-test-buffer'
+(require 'cl-lib) ; `cl-defmacro'
+
+;; Make sure the exact Emacs version can be found in the build output
+(message "Running tests on Emacs %s" emacs-version)
+
+(when (require 'undercover nil t)
+  (progn
+    (undercover "ac-php.el")
+    (undercover "ac-php-core.el")
+    (undercover "company-php.el")
+    (undercover "helm-ac-php-apropros.el")))
+
+(let* ((current-file (if load-in-progress load-file-name (buffer-file-name)))
+       (source-directory (locate-dominating-file current-file "Cask"))
+       ;; Don't load old byte-compiled versions
+       (load-prefer-newer t))
+  ;; Load the file under test
+  (load (expand-file-name "ac-php" source-directory))
+  (load (expand-file-name "ac-php-core" source-directory))
+  (load (expand-file-name "company-php" source-directory))
+  (load (expand-file-name "helm-ac-php-apropros" source-directory)))
+
+;;; test-helper.el ends here

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-cd `dirname $0`
-rm -f  ../ac-php.elc
-emacs -batch -l ert -l ac-php-test.el -f ert-run-tests-batch-and-exit


### PR DESCRIPTION
#### Updated documentation and code cleanup

- **`ac-php-get-tags-file`**
- **`ac-php--get-project-root-dir`**
- **`ac-php--get-tags-save-dir`**
- **`ac-php--get-config`**
- **`ac-php--json-save-data`**
- **`ac-php--get-timestamp`**
- **`ac-php--remake-tags`**
- **`ac-php--remake-tags-ex`**

#### Fixes and improvements

- **`ac-php--get-tags-save-dir`**, More accurate path cleaning.
   Covered use cases for `/a/b/c/d///////` or `/a/b/c/d\` 

- **`ac-php--get-config`**,  Covered use case for `echo '' > .ac-php-conf.json`.
   Notice `f-size` is not 0 in that case.
- Improved debug output

#### New functions

- **`ac-php--reduce-path`**, Return a modified version of PATH no longer than MAX-LEN.
     Currently used to debug output. For example:
     ```elisp
     (setq tags-file
              (concat "/home/klay/work/.emacs.d"
                      "/.local/packages/26.1/elpa/"
                      "ac-php-core-20190329.738/ac-php-comm-tags-data.el"))

     (ac-php--reduce-path tags-file 60)
     "~/w/././p/2/e/a/ac-php-comm-tags-data.el"
     ```

#### New constants

- **`ac-php-config-file`**, Per-project configuration file. (`.ac-php-conf.json`)

#### Testing

- Added initial Travis CI config
- Introduced Makefile:

```bash
$ make help
AC PHP 

Run `make init` first to install and update all local dependencies.

Available targets:
  help:     Show this help and exit
  init:     Initialise the project (has to be launched first)
  checkdoc: Checks AC PHP code for errors in documentation
  build:    Byte compile AC PHP package
  test:     Run the non-interactive unit test suite
  clean:    Remove all byte compiled Elisp files

Available programs:
  cask: yes

You need cask to develop AC PHP.  See http://cask.readthedocs.io/ for more.
```

```bash
$ make test
Running tests on Emacs 26.1
# ...
Running 19 tests (2019-03-30 17:48:14+0200)

   passed   1/19  ( 0.00s)  ac-php-test-parse-line-1
   passed   2/19  ( 0.00s)  ac-php-test-parse-line-10
   passed   3/19  ( 0.00s)  ac-php-test-parse-line-11
   passed   4/19  ( 0.00s)  ac-php-test-parse-line-12
   passed   5/19  ( 0.00s)  ac-php-test-parse-line-13
   passed   6/19  ( 0.00s)  ac-php-test-parse-line-14
   passed   7/19  ( 0.00s)  ac-php-test-parse-line-15
   passed   8/19  ( 0.00s)  ac-php-test-parse-line-16
   passed   9/19  ( 0.00s)  ac-php-test-parse-line-17
   passed  10/19  ( 0.00s)  ac-php-test-parse-line-18
   passed  11/19  ( 0.00s)  ac-php-test-parse-line-19
   passed  12/19  ( 0.00s)  ac-php-test-parse-line-2
   passed  13/19  ( 0.00s)  ac-php-test-parse-line-21
   passed  14/19  ( 0.00s)  ac-php-test-parse-line-3
   passed  15/19  ( 0.00s)  ac-php-test-parse-line-4
   passed  16/19  ( 0.00s)  ac-php-test-parse-line-5
   passed  17/19  ( 0.00s)  ac-php-test-parse-line-6
   passed  18/19  ( 0.00s)  ac-php-test-parse-line-7
   passed  19/19  ( 0.00s)  ac-php-test-parse-line-8

Ran 19 tests, 19 results as expected (2019-03-30 17:48:14+0200)
```