### PR TITLE
Cleaned up the ac-php-get-class-at-point

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ You can install `ac-php` manually by adding following to your init file :
 | `ac-php-find-symbol-at-point` | Jump to definition                                         |
 | `ac-php-location-stack-back`  | Return back                                                |
 | `ac-php-show-tip`             | Show definition at point                                   |
+| `ac-php-toggle-debug`         | Toggle debug mode                                          |
 | `helm-ac-php-apropos`         | Search through all the definitions of a project with helm  |
 
 ### auto-complete

--- a/ac-php-core.el
+++ b/ac-php-core.el
@@ -51,7 +51,7 @@
 (require 'f)     ; `f-write-text', `f-full', `f-join', `f-exists?', ...
 
 (require 'popup) ; `popup-tip'
-(require 'cl)    ; `reduce'
+(require 'cl)    ; `reduce', `defun*'
 (require 'dash)
 (require 'eldoc)
 
@@ -726,7 +726,7 @@ then this function split it to
           (end-of-line))))
     ret-list ))
 
-(defun ac-php-get-class-at-point (tags-data &optional pos)
+(defun* ac-php-get-class-at-point (tags-data &optional pos)
   "Docstring."
   (let (line-txt
         old-line-txt
@@ -745,13 +745,17 @@ then this function split it to
                     (buffer-substring-no-properties
                      (line-beginning-position) pos)))
 
+    ;; Get out early from function
+    (when (= (length line-txt) 0)
+      (return-from ac-php-get-class-at-point))
+
     ;; Looking for method chaining like this:
     ;;
     ;;   $class->method1()
     ;;         ->method2()
     ;;         ->method3();
     ;;
-    ;; And sets the ‘line-txt’ variable to:
+    ;; and setting the ‘line-txt’ variable to:
     ;;
     ;;   $class->method1()->method2()->method3();
     ;;
@@ -779,7 +783,7 @@ then this function split it to
     ;;
     ;;   array ($foo, "bar")
     ;;
-    ;; And sets the ‘line-txt’ variable to:
+    ;; and setting the ‘line-txt’ variable to:
     ;;
     ;;   $foo->bar
     ;;
@@ -796,7 +800,7 @@ then this function split it to
     ;;
     ;;   [$foo, "bar"]
     ;;
-    ;; And sets the ‘line-txt’ variable to:
+    ;; and setting the ‘line-txt’ variable to:
     ;;
     ;;   $foo->bar
     ;;


### PR DESCRIPTION
- Cleaned up the `ac-php-get-class-at-point`
- Renamed `ac-php--check-is-comment` => `ac-php--in-comment-p`
- Get out early from the `ac-php-get-class-at-point` (`defun` => `defun*`)
- Updated documentation