### PR TITLE
Code cleanup, fixed warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,9 @@
 
 SHELL := $(shell which bash)
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-EMACS := emacs
-CASK = cask
+EMACS ?= emacs
+CASK ?= cask
+PANDOC ?= pandoc --atx-headers
 EMACSFLAGS ?=
 TESTFLAGS ?= --reporter ert+duration
 PKGDIR := $(shell EMACS=$(EMACS) $(CASK) package-directory)
@@ -59,6 +60,9 @@ endif
 $(PKGDIR): Cask
 	$(CASK) install
 	touch $(PKGDIR)
+
+README: README.md
+	$(PANDOC) -t plain -o $@ $^
 
 # Public targets
 

--- a/ac-php-core.el
+++ b/ac-php-core.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 2014-2019 jim
 
 ;; Author: jim <xcwenn@qq.com>
+;;      Serghei Iakovlev <sadhooklay@gmail.com>
 ;; Maintainer: jim
 ;; URL: https://github.com/xcwen/ac-php
 ;; Keywords: completion, convenience, intellisense

--- a/cp2elpa.sh
+++ b/cp2elpa.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# This allows the configuration of the package path as follows:
-#     - .cp2elpa.sh
-#     - PACKAGE_USER_DIR=~/.emacs.d/.local/packages/ .cp2elpa.sh
+# This allows the configuration of the packages path as follows:
+#     - PACKAGE_USER_DIR=~/.local/state/emacs/elpa .cp2elpa.sh
+#     - PACKAGE_USER_DIR=~/.emacs.d/.local/packages .cp2elpa.sh
 : ${PACKAGE_USER_DIR:=~/.emacs.d/elpa}
 
 cd `dirname $0`

--- a/test/ac-php-test.el
+++ b/test/ac-php-test.el
@@ -118,48 +118,44 @@ run with specific customizations set."
   (let (line-txt  ret )
     (setq line-txt "  \t $this->func1()->s")
     (setq  ret '("this" "." "func1(" "." "s" ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
-
-(defun ac-php-test--parse-line ( line-txt ret)
-  (should (equal  (ac-php-remove-unnecessary-items-4-complete-method
-                   (ac-php-split-line-4-complete-method line-txt ))
-                  ret)))
 
 (ert-deftest ac-php-test-parse-line-2 ()
   "text"
   (let (line-txt  ret )
     (setq line-txt " this->asdfa ( \t (new class1( ))->run()->ss")
     (setq  ret '("class1(" "." "run(" "." "ss" ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
+
 (ert-deftest ac-php-test-parse-line-3 ()
   "text"
   (let (line-txt  ret )
     (setq line-txt " $this->func")
     (setq  ret '("this" "." "func"  ))
-    (ac-php-test--parse-line line-txt ret  )
-    ))
+    (ac-php-test-parse-equal line-txt ret)))
+
 (ert-deftest ac-php-test-parse-line-4 ()
   "text"
   (let (line-txt  ret )
     (setq line-txt "this")
     (setq  ret '("this"  ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 (ert-deftest ac-php-test-parse-line-5 ()
   "text"
   (let (line-txt  ret )
     (setq line-txt "return this->sdfa&& this->ttt->ss")
     (setq  ret '("this" "." "ttt" "." "ss"  ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 (ert-deftest ac-php-test-parse-line-6 ()
   "text"
   (let (line-txt  ret )
     (setq line-txt "return this->sdfa ||  ClassT::getV")
     (setq  ret '("ClassT::" "." "getV"   ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 
 
@@ -169,7 +165,7 @@ run with specific customizations set."
   (let (line-txt  ret )
     (setq line-txt "return (($this->tt())->kk())->ss ")
     (setq  ret '("this" "." "tt("   "." "kk(" "."  "ss"  ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 
 
@@ -178,7 +174,7 @@ run with specific customizations set."
   (let (line-txt  ret )
     (setq line-txt "\"sdfa\" => $this->tt ")
     (setq  ret '("this" "." "tt"     ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 
 
@@ -190,14 +186,14 @@ run with specific customizations set."
   (let (line-txt  ret )
     (setq line-txt "$ss > $this->tt ")
     (setq  ret '("this" "." "tt"     ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 (ert-deftest ac-php-test-parse-line-21 ()
   "text"
   (let (line-txt  ret )
     (setq line-txt "  } else  if ($role   == Erole:: ")
     (setq  ret '("Erole::" "."      ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 
 
@@ -206,14 +202,14 @@ run with specific customizations set."
   (let (line-txt  ret )
     (setq line-txt "$ss <= $this->tt ")
     (setq  ret '("this" "." "tt"     ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 
 (ert-deftest ac-php-test-parse-line-12 ()
   (let (line-txt  ret )
     (setq line-txt "$this->ss(0 <= $this->tt)->kk ")
     (setq  ret '("this" "." "ss(" "." "kk"     ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 
 
@@ -221,20 +217,20 @@ run with specific customizations set."
   (let (line-txt  ret )
     (setq line-txt "$this->ss? this->tt ")
     (setq  ret '("this" "." "tt"     ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 
 (ert-deftest ac-php-test-parse-line-14 ()
   (let (line-txt  ret )
     (setq line-txt "   \t  tt ")
     (setq  ret '("tt"     ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 (ert-deftest ac-php-test-parse-line-15 ()
   (let (line-txt  ret )
     (setq line-txt "   \t  if (this->ss?this->tt ")
     (setq  ret '("this" "." "tt"     ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 
 
@@ -242,20 +238,20 @@ run with specific customizations set."
   (let (line-txt  ret )
     (setq line-txt "   \t  if (this->ss?this->tt:this->kk ")
     (setq  ret '("this" "." "kk"     ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 
 (ert-deftest ac-php-test-parse-line-17 ()
   (let (line-txt  ret )
     (setq line-txt "   \t  parent::ss")
     (setq  ret '( "parent::" "."  "ss"   ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 (ert-deftest ac-php-test-parse-line-18 ()
   (let (line-txt  ret )
     (setq line-txt "   \t $v >= $ff? \"sdfa\" : parent::ss . parent::xx")
     (setq  ret '("parent::"  "." "xx"  ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 
 
@@ -264,7 +260,7 @@ run with specific customizations set."
   (let (line-txt  ret )
     (setq line-txt "(yii\\web\\Application(config))->ru")
     (setq  ret '("yii\\web\\Application" "." "ru"   ))
-    (ac-php-test--parse-line line-txt ret  )
+    (ac-php-test-parse-equal line-txt ret  )
     ))
 
 

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -54,4 +54,10 @@
   (load (expand-file-name "company-php" source-directory))
   (load (expand-file-name "helm-ac-php-apropros" source-directory)))
 
+(defun ac-php-test-parse-equal (line expected)
+  "Verifies that after parsing LINE will be the same as EXPECTED."
+  (let* ((splitted (ac-php-split-line-4-complete-method line))
+         (actual (ac-php-remove-unnecessary-items-4-complete-method splitted)))
+    (should (equal actual expected))))
+
 ;;; test-helper.el ends here


### PR DESCRIPTION
#### Added
- Added Makefile target to generate plain text README

#### Fixed
- Removed compilation warning for `find-tag-marker-ring`

#### Removed
- Removed no longer needed `ac-php-check-not-in-string-or-comment` and `ac-php-check-not-in-comment`

#### Renamed
- Renamed `ac-php-test--parse-line` to `ac-php-test-parse-equal`

#### Minor
- Code cleanup
- Updated documentation