### PR TITLE
Fixed ac-php--get-node-parser-data

### DIFF
--- a/ac-php.el
+++ b/ac-php.el
@@ -1,14 +1,15 @@
 ;;; ac-php.el --- auto-completion source for php
 
-;; Copyright (C) 2014-2019 jim
+;; Copyright (C) 2014-2019 jim <xcwenn@qq.com>
 
 ;; Author: jim <xcwenn@qq.com>
 ;; Maintainer: jim
 ;; URL: https://github.com/xcwen/ac-php
 ;; Keywords: completion, convenience, intellisense
-;; Package-Requires: ((emacs "24.4") (ac-php-core "1") (auto-complete "1.4.0") (yasnippet "0.8.0"))
+;; Package-Requires: ((ac-php-core "2.0") (auto-complete "1.4.0") (yasnippet "0.8.0"))
+;; Compatibility: GNU Emacs: 24.4, 25.x, 26.x, 27.x
 
-;; This file is not part of GNU Emacs.
+;; This file is NOT part of GNU Emacs.
 
 ;;; License
 
@@ -30,11 +31,6 @@
 ;; Auto Completion source for PHP.  Known to work on Linux and macOS systems.
 ;; For more info and examples see URL `https://github.com/xcwen/ac-php' .
 ;;
-;; Thanks to:
-;; - auto-complete-clang
-;; - auto-java-complete (ac-php-remove-unnecessary-items-4-complete-method)
-;; - rtags (ac-php-location-stack-index)
-;;
 ;; Usage:  Put this package in your Emacs Lisp path (eg. site-lisp) and add to
 ;; your .emacs file:
 ;;
@@ -53,6 +49,9 @@
 ;; Many options available under Help:Customize
 ;; Options specific to ac-php are in
 ;;   Convenience/Completion/Auto Complete
+;;
+;; Known to work with Linux and macOS.  Windows support is in beta stage.
+;; For more info and examples see URL `https://github.com/xcwen/ac-php' .
 ;;
 ;; Bugs: Bug tracking is currently handled using the GitHub issue tracker
 ;; (see URL `https://github.com/xcwen/ac-php/issues')

--- a/company-php.el
+++ b/company-php.el
@@ -1,10 +1,17 @@
-;;; company-php.el --- company completion source for php
-;; Copyright (C) 2014 - 2016 jim
-;; Author: xcwenn@qq.com [https://github.com/xcwen]
+;;; company-php.el --- A company back-end for PHP
+
+;; Copyright (C) 2014-2019 jim <xcwenn@qq.com>
+
+;; Author: jim <xcwenn@qq.com>
+;; Maintainer: jim
 ;; URL: https://github.com/xcwen/ac-php
-;; Package-Version: 20171209.2243
 ;; Keywords: completion, convenience, intellisense
-;; Package-Requires: ((emacs "24.4") (cl-lib "0.5") (ac-php-core "1") (company "0.9"))
+;; Package-Requires: ((cl-lib "0.5") (ac-php-core "2.0") (company "0.9"))
+;; Compatibility: GNU Emacs: 24.4, 25.x, 26.x, 27.x
+
+;; This file is NOT part of GNU Emacs.
+
+;;; License
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -20,16 +27,25 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;  company source for php.
-;; support  Linux and OSX,  but windows need more test
-;; More info and **example** at : https://github.com/xcwen/ac-php
 
-;;(add-hook 'php-mode-hook
-;;          '(lambda ()
+;; A company back-end for PHP.
+;;
+;; (add-hook 'php-mode-hook
+;;           '(lambda ()
 ;;             (require 'company-php)
 ;;             (company-mode t)
 ;;             (add-to-list 'company-backends 'company-ac-php-backend )))
-
+;;
+;; Many options available under Help:Customize
+;; Options specific to ac-php are in
+;;   Convenience/Completion/Auto Complete
+;;   Convenience/Completion/Company
+;;
+;; Known to work with Linux and macOS.  Windows support is in beta stage.
+;; For more info and examples see URL `https://github.com/xcwen/ac-php' .
+;;
+;; Bugs: Bug tracking is currently handled using the GitHub issue tracker
+;; (see URL `https://github.com/xcwen/ac-php/issues')
 
 ;;; Code:
 

--- a/helm-ac-php-apropros.el
+++ b/helm-ac-php-apropros.el
@@ -1,10 +1,17 @@
-;;; helm-ac-php-apropros.el --- An helm apropos of all defined symbols in an ac-php project.  -*- lexical-binding: t; -*-
+;;; helm-ac-php-apropros.el --- A helm apropos.  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2018  Antoine Brand
+;; Copyright (C) 2018  Antoine Brand <antoine597@gmail.com>
 
 ;; Author: Antoine Brand <antoine597@gmail.com>
+;; Maintainer: jim
+;; URL: https://github.com/xcwen/ac-php
 ;; Keywords: convenience, helm
-;; Package-Requires: ((emacs "24.4") (helm "1"))
+;; Package-Requires: ((ac-php-core "2.0.3") (helm "1"))
+;; Compatibility: GNU Emacs: 24.4, 25.x, 26.x, 27.x
+
+;; This file is NOT part of GNU Emacs.
+
+;;; License
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -22,6 +29,16 @@
 ;;; Commentary:
 
 ;; An apropos functionality using the ac-php index and helm as interface.
+;;
+;; Many options available under Help:Customize
+;; Options specific to ac-php are in
+;;   Convenience/Completion/Auto Complete
+;;
+;; Known to work with Linux and macOS.  Windows support is in beta stage.
+;; For more info and examples see URL `https://github.com/xcwen/ac-php' .
+;;
+;; Bugs: Bug tracking is currently handled using the GitHub issue tracker
+;; (see URL `https://github.com/xcwen/ac-php/issues')
 
 ;;; Code:
 


### PR DESCRIPTION
- Fixed `ac-php--get-node-parser-data
- Code cleanup
- Update documentation

The `ac-php--get-node-parser-data` worked incorrectly.
 Previous implementation just did the following test:
```elisp
(when last-item
    (setq ret-data (ac-php--get-node-parser-data last-item)))
```

However `last-item` may be a string, not a list. So I fixed this.  However I'll need to verify that
all still works as expected.  Consider this as an experimental branch.