### PR TITLE
Fix false-positive test for annotated class

### DIFF
--- a/test/ac-php-search-test.el
+++ b/test/ac-php-search-test.el
@@ -256,5 +256,31 @@ function helper() {}"
    (goto-char (point-max))
    (should (eq (ac-php-get-annotated-var-class "extension") nil))))
 
+(ert-deftest ac-php-search/annotated-var-out-of-scope ()
+  :tags '(re search)
+  (ac-php-test-with-temp-buffer "
+function hello() {
+    /** @var Extension $extension */
+}
+
+function test() {
+
+}"
+   (goto-char (point-max))
+   (should (eq (ac-php-get-annotated-var-class "extension") nil))))
+
+(ert-deftest ac-php-search/annotated-var-out-correct-scope ()
+  :tags '(re search)
+  (ac-php-test-with-temp-buffer "
+function hello() {
+    /** @var Extension $extension */
+}
+
+function test() {
+    /** @var Fake $extension */
+}"
+   (goto-char (point-max))
+   (should (string= (ac-php-get-annotated-var-class "extension") "Fake"))))
+
 (provide 'ac-php-search-test)
 ;;; ac-php-search-test.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -35,9 +35,6 @@
 (require 'cl-lib) ; `cl-defmacro'
 (require 'php-mode)
 
-;; reading/writing/loading compressed files
-(require 'jka-compr)
-
 ;; Make sure the exact Emacs version can be found in the build output
 (message "Running tests on Emacs %s" emacs-version)
 
@@ -53,10 +50,10 @@
        ;; Don't load old byte-compiled versions
        (load-prefer-newer t))
   ;; Load the file under test
-  (load (expand-file-name "ac-php" source-directory))
-  (load (expand-file-name "ac-php-core" source-directory))
-  (load (expand-file-name "company-php" source-directory))
-  (load (expand-file-name "helm-ac-php-apropros" source-directory)))
+  (load (expand-file-name "ac-php" source-directory) nil t)
+  (load (expand-file-name "ac-php-core" source-directory) nil t)
+  (load (expand-file-name "company-php" source-directory) nil t)
+  (load (expand-file-name "helm-ac-php-apropros" source-directory) nil t))
 
 (defmacro ac-php-test-with-temp-buffer (content &rest body)
   "Evaluate BODY in a temporary buffer with CONTENT."


### PR DESCRIPTION
`ac-php-get-annotated-var-class`  should use current function scope only.

```php
function hello() {
    /** @var Extension $extension */
}

function test($extension) {
    $extension->...
//                ^
//                Point here
}
```


