### PR TITLE
[WIP] Added test for false-positive for an annotated class

### DIFF
--- a/test/ac-php-search-test.el
+++ b/test/ac-php-search-test.el
@@ -282,5 +282,21 @@ function test() {
    (goto-char (point-max))
    (should (string= (ac-php-get-annotated-var-class "extension") "Fake"))))
 
+(ert-deftest ac-php-search/annotated-var-out-of-function ()
+  :tags '(re search)
+  (ac-php-test-with-temp-buffer "
+/** @var Fake $extension */
+$extension->bar();
+
+function hello($extension) {
+    /** @var Extension $extension */
+    $extension->foo();
+}
+
+$extension->bar();
+"
+   (goto-char (point-max))
+   (should (string= (ac-php-get-annotated-var-class "extension") "Fake"))))
+
 (provide 'ac-php-search-test)
 ;;; ac-php-search-test.el ends here


### PR DESCRIPTION
```php
/** @var Fake $extension */
$extension->bar();

function hello($factory) {
    /** @var Extension $extension */
    $extension = $factory->create();
    $extension->foo();
}

$extension->...
//            ^
//            Point is here
```

**Actual** result:
```elisp
(ac-php-get-annotated-var-class "extension")
;; Extension
```

**Expected** result:
```elisp
(ac-php-get-annotated-var-class "extension")
;; Fake
```
