### PR TITLE
Added ac-php--in-function-p inline function

### DIFF
--- a/ac-php-core.el
+++ b/ac-php-core.el
@@ -299,15 +299,25 @@ left to try and get the path down to MAX-LEN"
   "Return a project path using the TAGS-DATA list."
   (nth 4 tags-data))
 
-(defun ac-php--in-comment-p (pos)
+(defsubst ac-php--in-comment-p (&optional pos)
   "Determine whether POS is inside a comment."
   (let ((state (save-excursion (syntax-ppss pos))))
     (nth 4 state)))
 
-(defsubst ac-php--in-string-or-comment-p (pos)
+(defsubst ac-php--in-string-or-comment-p (&optional pos)
   "Determine whether POS is inside a string or comment."
   (let ((state (save-excursion (syntax-ppss pos))))
     (nth 8 state)))
+
+(defsubst ac-php--in-function-p (&optional pos)
+  "Determine whether POS is inside a function."
+  (unless pos (setq pos (point)))
+  (let ((bof (save-excursion (beginning-of-defun) (point)))
+        (eof (save-excursion (end-of-defun) (point))))
+    (cond
+     ((or (null bof) (null eof)) nil)
+     ((and (> pos bof) (< pos eof)) t)
+     (t nil))))
 
 (defun ac-php-toggle-debug ()
   "Toggle debug mode.

--- a/test/ac-php-utils-test.el
+++ b/test/ac-php-utils-test.el
@@ -1,0 +1,52 @@
+;;; ac-php-utils-test.el --- Utils tests -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2014-2019 jim <xcwenn@qq.com>
+;; Copyright (C) 2019 Serghei Iakovlev <sadhooklay@gmail.com>
+
+;; Author: jim <xcwenn@qq.com>
+;; Maintainer: jim
+;; URL: https://github.com/xcwen/ac-php
+
+;; This file is not part of GNU Emacs.
+
+;;; License
+
+;; This file is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this file; if not, write to the Free Software
+;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+;; 02110-1301, USA.
+
+;;; Commentary:
+
+;; Automate tests from the "test" directory using `ert', which comes bundled
+;; with Emacs >= 24.1.
+
+;;; Code:
+
+(ert-deftest ac-php-search/in-function-std-case ()
+  :tags '(re search)
+  (ac-php-test-with-temp-buffer
+   "<?php
+function foo () {
+
+}"
+   (goto-char (point-max))
+   (should (eq (ac-php--in-function-p) nil))
+   (should (eq (ac-php--in-function-p (1- (point))) t))
+   (should (eq (ac-php--in-function-p 1) nil))
+   (should (eq (ac-php--in-function-p 24) t))
+   (goto-char (point-min))
+   (should (eq (ac-php--in-function-p 24) t))))
+
+(provide 'ac-php-utils-test)
+;;; ac-php-utils-test.el ends here


### PR DESCRIPTION
Consider some examples to understand how it works.

##### Example 1
```php
function foo () {

}

X <-- point
```

```elisp
(ac-php--in-function-p) ;; nil
```

##### Example 2
```php
function foo () {
X <-- point
}
```

```elisp
(ac-php--in-function-p) ;; t
```

##### Example 3
```php
X <-- pont
function foo () {

}
```

```elisp
(ac-php--in-function-p) ;; nil
```
--- 

Aimed to use for: https://github.com/xcwen/ac-php/pull/128
