### PR TITLE
 Refactor ac-php-get-syntax-backward 

### DIFF
--- a/ac-php-core.el
+++ b/ac-php-core.el
@@ -354,6 +354,7 @@ See `ac-php-beginning-of-defun'."
   "Determine whether POS is inside a function."
   (let (bof (pos (or pos (point))))
     (save-excursion
+      (goto-char pos)
       (when (ac-php-beginning-of-defun)
         (setq bof (point))
         (ac-php-end-of-defun)

--- a/test/ac-php-utils-test.el
+++ b/test/ac-php-utils-test.el
@@ -46,7 +46,7 @@ function foo () {
    (should (eq (ac-php--in-function-p 1) nil))
    (should (eq (ac-php--in-function-p 24) t))
    (goto-char (point-min))
-   (should (eq (ac-php--in-function-p) nil))))
+   (should (eq (ac-php--in-function-p 24) t))))
 
 (provide 'ac-php-utils-test)
 ;;; ac-php-utils-test.el ends here


### PR DESCRIPTION
All additional parameters were moved to property list:
```elisp
(ac-php-get-syntax-backward regexp-string
   :sexp 1
   :comment t
   :bound (save-excursion (beginning-of-defun) (beginning-of-line) (point))))
```

Possible additional ARGS:

    :sexp       Specifies which parenthesized expression in the REGEXP
                should be returned.

    :comment    Indicates should we search inside a comment or not.

    :bound      A buffer position that bounds the search.  The match found must
                not end after that position.  A value of nil means search to the
                end of the accessible portion of the buffer.