### PR TITLE
Fixed compilation warnings

### DIFF
--- a/Cask
+++ b/Cask
@@ -14,7 +14,6 @@
 (depends-on "f" "0.17.0")
 (depends-on "popup" "0.5.0")
 (depends-on "dash" "1")
-(depends-on "xscope" "1.0")
 
 ;; ac-php.el
 (depends-on "auto-complete" "1.4.0")

--- a/Cask
+++ b/Cask
@@ -14,7 +14,7 @@
 (depends-on "f" "0.17.0")
 (depends-on "popup" "0.5.0")
 (depends-on "dash" "1")
-
+(depends-on "xcscope" "1.0")
 ;; ac-php.el
 (depends-on "auto-complete" "1.4.0")
 (depends-on "yasnippet" "0.8.0")

--- a/Cask
+++ b/Cask
@@ -1,4 +1,4 @@
-;; -*- mode: emacs-lisp -*-
+;; -*- mode: cask -*-
 
 (source gnu)
 (source melpa)
@@ -14,6 +14,7 @@
 (depends-on "f" "0.17.0")
 (depends-on "popup" "0.5.0")
 (depends-on "dash" "1")
+(depends-on "xscope" "1.0")
 
 ;; ac-php.el
 (depends-on "auto-complete" "1.4.0")

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Prerequisite packages are:
   - [f][:melpa-f:]
   - [popup][:melpa-popup:]
   - [dash][:elpa-dash:]
-  - [xscope][:gh-xscope:] (optional)
+  - [xcscope][:melpa-xcscope:] (optional)
   - [scope][:sf-cscope:] (optional)
 - **`ac-php.el`**
   - [auto-complete][:gh-ac:]
@@ -525,7 +525,6 @@ ac-php is open source software licensed under the GNU General Public Licence ver
 [:gh-helm:]: https://github.com/emacs-helm/helm
 [:gh-php-mode:]: https://github.com/emacs-php/php-mode
 [:gh-yasnippet:]: https://github.com/joaotavora/yasnippet
-[:gh-xscope:]: https://github.com/dkogan/xcscope.el
 [:melpa-gs:]: https://melpa.org/#/getting-started
 [:phpstorm-stubs:]: https://github.com/JetBrains/phpstorm-stubs
 [:issue-example:]: https://github.com/xcwen/ac-php/issues/51
@@ -535,4 +534,5 @@ ac-php is open source software licensed under the GNU General Public Licence ver
 [:melpa-f:]: https://melpa.org/#/f
 [:melpa-s:]: https://melpa.org/#/s
 [:melpa-popup:]: https://melpa.org/#/popup
+[:meplpa-xscope:]: https://melpa.org/#/xcscope
 [:sf-cscope:]: http://cscope.sourceforge.net

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Prerequisite packages are:
   - [f][:melpa-f:]
   - [popup][:melpa-popup:]
   - [dash][:elpa-dash:]
+  - [xscope][:gh-xscope:] (optional)
   - [scope][:sf-cscope:] (optional)
 - **`ac-php.el`**
   - [auto-complete][:gh-ac:]
@@ -524,6 +525,7 @@ ac-php is open source software licensed under the GNU General Public Licence ver
 [:gh-helm:]: https://github.com/emacs-helm/helm
 [:gh-php-mode:]: https://github.com/emacs-php/php-mode
 [:gh-yasnippet:]: https://github.com/joaotavora/yasnippet
+[:gh-xscope:]: https://github.com/dkogan/xcscope.el
 [:melpa-gs:]: https://melpa.org/#/getting-started
 [:phpstorm-stubs:]: https://github.com/JetBrains/phpstorm-stubs
 [:issue-example:]: https://github.com/xcwen/ac-php/issues/51

--- a/ac-php-core.el
+++ b/ac-php-core.el
@@ -85,7 +85,7 @@
   (if (and (= emacs-major-version 24) (>= emacs-minor-version 4))
       (require 'cl)))
 
-(require 'cl-lib) ; `cl-reduce', `cl-defun'
+(require 'cl-lib) ; `cl-reduce'
 
 ;;; Customization
 
@@ -1026,7 +1026,7 @@ work for multi class hint:
      :bound (when in-defun-p
               (save-excursion (beginning-of-defun) (beginning-of-line) (point))))))
 
-(cl-defun ac-php-get-class-at-point (tags-data &optional pos)
+(defun ac-php-get-class-at-point (tags-data &optional pos)
   "Docstring."
   (let (line-txt
         old-line-txt
@@ -1045,8 +1045,9 @@ work for multi class hint:
                      (line-beginning-position) pos)))
 
     ;; Get out early from function
-    (when (= (length line-txt) 0)
-      (return-from ac-php-get-class-at-point))
+    (catch 'empty-code
+      (when (= (length line-txt) 0)
+        (throw 'empty-code "Got empty string")))
 
     ;; Looking for method chaining like this:
     ;;

--- a/ac-php-core.el
+++ b/ac-php-core.el
@@ -12,7 +12,7 @@
 ;; URL: https://github.com/xcwen/ac-php
 ;; Version: 2.0.8
 ;; Keywords: completion, convenience, intellisense
-;; Package-Requires: ((dash "1") (php-mode "1") (s "1") (f "0.17.0") (popup "0.5.0") (xscope "1.0"))
+;; Package-Requires: ((dash "1") (php-mode "1") (s "1") (f "0.17.0") (popup "0.5.0") (xcscope "1.0"))
 ;; Compatibility: GNU Emacs: 24.4, 25.x, 26.x, 27.x
 
 ;; This file is NOT part of GNU Emacs.
@@ -72,12 +72,12 @@
 
 ;;; Code:
 
-(require 'json)  ; `json-encode', `json-read-file'
-(require 's)     ; `s-equals', `s-upcase', `s-matches-p', `s-replace', ...
-(require 'f)     ; `f-write-text', `f-full', `f-join', `f-exists?', ...
+(require 'json)    ; `json-encode', `json-read-file'
+(require 's)       ; `s-equals', `s-upcase', `s-matches-p', `s-replace', ...
+(require 'f)       ; `f-write-text', `f-full', `f-join', `f-exists?', ...
 
-(require 'xcscope nil t) ; `cscope-find-egrep-pattern', `cscope-prompt-for-symbol'
-(require 'popup) ; `popup-tip'
+(require 'xcscope) ; `cscope-find-egrep-pattern', `cscope-prompt-for-symbol'
+(require 'popup)   ; `popup-tip'
 (require 'dash)
 (require 'eldoc)
 
@@ -2625,21 +2625,17 @@ Return empty string if there is no valid sequence of characters."
 (defun ac-php-cscope-find-egrep-pattern (symbol)
   "Set `cscope-initial-directory' and run egrep over the cscope database."
   (interactive
-   ;; TODO: refactor
    (list
     (let (cscope-no-mouse-prompts)
-      ;; TODO: check for fboundp
       (cscope-prompt-for-symbol "Find this egrep pattern " nil t t))))
   (let ((project-root-dir (ac-php--get-project-root-dir)))
 
     (if (or ac-php-use-cscope-flag
             (ac-php--get-use-cscope-from-config-file project-root-dir))
         (progn
-          (when (boundp 'cscope-initial-directory)
-            (setq cscope-initial-directory
-                  (ac-php--get-tags-save-dir project-root-dir)))
-          (when (fboundp 'cscope-find-egrep-pattern)
-            (cscope-find-egrep-pattern symbol)))
+          (setq cscope-initial-directory
+                (ac-php--get-tags-save-dir project-root-dir))
+          (cscope-find-egrep-pattern symbol))
       (message "need config: %s -> use-cscope:true" ac-php-config-file))))
 
 (defun ac-php-eldoc-documentation-function ()

--- a/ac-php-core.el
+++ b/ac-php-core.el
@@ -12,7 +12,7 @@
 ;; URL: https://github.com/xcwen/ac-php
 ;; Version: 2.0.8
 ;; Keywords: completion, convenience, intellisense
-;; Package-Requires: ((dash "1") (php-mode "1") (s "1") (f "0.17.0") (popup "0.5.0"))
+;; Package-Requires: ((dash "1") (php-mode "1") (s "1") (f "0.17.0") (popup "0.5.0") (xscope "1.0"))
 ;; Compatibility: GNU Emacs: 24.4, 25.x, 26.x, 27.x
 
 ;; This file is NOT part of GNU Emacs.
@@ -76,10 +76,16 @@
 (require 's)     ; `s-equals', `s-upcase', `s-matches-p', `s-replace', ...
 (require 'f)     ; `f-write-text', `f-full', `f-join', `f-exists?', ...
 
+(require 'xcscope nil t) ; `cscope-find-egrep-pattern', `cscope-prompt-for-symbol'
 (require 'popup) ; `popup-tip'
-(require 'cl)    ; `reduce', `defun*'
 (require 'dash)
 (require 'eldoc)
+
+(eval-and-compile
+  (if (and (= emacs-major-version 24) (>= emacs-minor-version 4))
+      (require 'cl)))
+
+(require 'cl-lib) ; `cl-reduce', `cl-defun'
 
 ;;; Customization
 
@@ -293,7 +299,7 @@ This function replaces some components with single characters starting from the
 left to try and get the path down to MAX-LEN"
   (let* ((components (split-string (abbreviate-file-name path) "/"))
          (len (+ (1- (length components))
-                 (reduce '+ components :key 'length)))
+                 (cl-reduce '+ components :key 'length)))
          (str ""))
     (while (and (> len max-len)
                 (cdr components))
@@ -302,7 +308,7 @@ left to try and get the path down to MAX-LEN"
                               (string (elt (car components) 0) ?/)))
             len (- len (1- (length (car components))))
             components (cdr components)))
-    (concat str (reduce (lambda (a b) (concat a "/" b)) components))))
+    (concat str (cl-reduce (lambda (a b) (concat a "/" b)) components))))
 
 (defun ac-php-g--project-root-dir (tags-data)
   "Return a project path using the TAGS-DATA list."
@@ -1020,7 +1026,7 @@ work for multi class hint:
      :bound (when in-defun-p
               (save-excursion (beginning-of-defun) (beginning-of-line) (point))))))
 
-(defun* ac-php-get-class-at-point (tags-data &optional pos)
+(cl-defun ac-php-get-class-at-point (tags-data &optional pos)
   "Docstring."
   (let (line-txt
         old-line-txt
@@ -1055,7 +1061,7 @@ work for multi class hint:
     (save-excursion
       (ac-php--debug "Looking for method chaining...")
       (while (and (> (length line-txt) 0) (= (aref line-txt 0) ?-))
-        (previous-line)
+        (forward-line -1)
         (let ((no-comment-code "")
               (line-start-pos (line-beginning-position))
               (line-end-pos (line-end-position)))
@@ -1313,10 +1319,15 @@ work for multi class hint:
    (gethash key-word function-map )
     )
 
-
 (defun ac-php-candidate-other ( tags-data)
-
-  (let (ret-list ( cur-word  (ac-php-get-cur-word-without-clean )) cur-word-len  cmp-value  start-word-pos (function-map (ac-php-g--function-map tags-data  )  ) key-word func-name  )
+  (let (ret-list
+        (cur-word (ac-php-get-cur-word-without-clean))
+        cur-word-len
+        cmp-value
+        start-word-pos
+        (function-map (ac-php-g--function-map tags-data))
+        key-word func-name
+        function-item-len)
 
     (setq cur-word-len (length cur-word ))
     (setq start-word-pos (- cur-word-len (length ac-php-prefix-str) ) )
@@ -1672,7 +1683,7 @@ This function is used internally by the function `ac-php--remake-tags'."
                ac-php-php-executable))
 
     (unless project-root-dir
-      (massge "ac-php: The per-project configuration file '%s' doesn't exist at %s"
+      (message "ac-php: The per-project configuration file '%s' doesn't exist at %s"
               ac-php-config-file
               (file-name-directory (buffer-file-name))))
 
@@ -1706,7 +1717,7 @@ be created."
           tag-dir (cdr (assoc-string "tag-dir" conf-list)))
 
     (if tag-dir
-        (prog
+        (progn
          (ac-php--debug "Found tags directory")
          (setq old-default-directory default-directory
                default-directory project-root-dir
@@ -1774,8 +1785,9 @@ If it is outdated, a re-index process will be performed."
 
 
 (defun ac-php--get-config (project-root-dir)
-  "Read the configuration loacated at PROJECT-ROOT-DIR and return it.
+  "Get configuration related to a project.
 
+Reads the configuration located at PROJECT-ROOT-DIR and returns it.
 This function tries to recreate and / or populate configuration
 file in case of its absence, or if it is empty."
   (ac-php--debug "Lookup for per-project configuration file...")
@@ -1895,7 +1907,8 @@ will be loaded and the in-memory storage will be updated."
         tags-new-mtime
         class-map
         function-map
-        inherit-map)
+        inherit-map
+        g-ac-php-tmp-tags)
     (when file-attr
       (setq tags-new-mtime (ac-php--get-timestamp (nth 5 file-attr))
             tags-old-mtime (nth 1 (assoc-string
@@ -1906,7 +1919,9 @@ will be loaded and the in-memory storage will be updated."
         (message (concat "ac-php: Reloading the autocompletion "
                          "data from the tags file..."))
         (load tags-file nil t)
-        (setq file-data g-ac-php-tmp-tags) ;;// g-ac-php-tmp-tags in tags.el
+
+        ;; `g-ac-php-tmp-tags' will be populated from tags.el file
+        (setq file-data g-ac-php-tmp-tags)
 
         (assq-delete-all tags-file ac-php-tag-last-data-list)
 
@@ -2386,48 +2401,42 @@ considered at this stage as a 'property usage', although in fact they may not be
                 )
               )
           (cond
-           ((or (string= type "class_member")  (string= type "user_function") )
-            (let ((file-pos (nth 1 symbol-ret) ) tmp-arr  )
-              (setq tmp-arr  (s-split ":" file-pos ) )
-              (ac-php--debug " tmp-arr %S"  tmp-arr )
+           ((or (string= type "class_member") (string= type "user_function") )
+            (let ((file-pos (nth 1 symbol-ret)) tmp-arr)
+              (setq tmp-arr  (s-split ":" file-pos))
+              (ac-php--debug " tmp-arr %S"  tmp-arr)
               (cond
-               ((s-matches-p "sys" (nth 0 tmp-arr) )
-                (let( (sys-item-name (aref  (nth 3 symbol-ret ) 1 )) ) ;;system function
+               ((s-matches-p "sys" (nth 0 tmp-arr))
+                (let( (sys-item-name (aref (nth 3 symbol-ret) 1))) ;;system function
                   ;; \trim( => trim
                   (if (string= type "user_function")
-                      (setq sys-item-name (substring-no-properties
-                                           sys-item-name 1
-                                           (if (string=  "(" ( substring  sys-item-name -1 )) -1 nil  )
-                                           )         )
-                    (setq sys-item-name  (nth 2 symbol-ret ) ) ;; class name
-                    )
-
-                  (php-search-documentation sys-item-name )
-                  ))
+                      (setq sys-item-name
+                            (substring-no-properties
+                             sys-item-name 1
+                             (if (string= "(" (substring  sys-item-name -1))
+                                 -1 nil)))
+                    ;; class name
+                    (setq sys-item-name (nth 2 symbol-ret)))
+                  (if (fboundp 'php-search-documentation)
+                      (php-search-documentation sys-item-name)
+                    (message "Unable to find php-search-documentation function"))))
                (t
-                (let ( (file-list (ac-php-g--file-list tags-data  ) )  )
+                (let ((file-list (ac-php-g--file-list tags-data)))
                   ;; from  get index
                   (setq jump-pos
                         (concat
-                         (aref file-list (string-to-number (nth 0 tmp-arr)  )  )
-                         ":" (nth 1 tmp-arr)
-                         ))
+                         (aref file-list (string-to-number (nth 0 tmp-arr)))
+                         ":" (nth 1 tmp-arr)))
                   (ac-php-location-stack-push)
-                  (ac-php-goto-location jump-pos )
-                  )
-                ))
-              )
-            )
-           )))
-      (when local-var-flag ( ac-php--goto-local-var-def local-var  ) )
-      )
-    ))
-
+                  (ac-php-goto-location jump-pos)))))))))
+      (when local-var-flag (ac-php--goto-local-var-def local-var)))))
 
 (defun ac-php-gen-def ()
   "DOCSTRING"
   (interactive)
-  (let ( (tags-data (ac-php-get-tags-data ) )  line-txt (cur-word  (ac-php--get-cur-word ) ) )
+  (let ((tags-data (ac-php-get-tags-data))
+        line-txt
+        (cur-word (ac-php--get-cur-word)))
     (setq line-txt (buffer-substring-no-properties
                     (line-beginning-position)
                     (line-end-position )))
@@ -2613,21 +2622,24 @@ Return empty string if there is no valid sequence of characters."
         )) )))
 
 (defun ac-php-cscope-find-egrep-pattern (symbol)
-  "auto set  cscope-initial-directory and  Run egrep over the cscope database."
-  (interactive (list
-                (let (cscope-no-mouse-prompts)
-                  (cscope-prompt-for-symbol "Find this egrep pattern " nil t t))
-                ))
-  (let ((project-root-dir ( ac-php--get-project-root-dir )))
+  "Set `cscope-initial-directory' and run egrep over the cscope database."
+  (interactive
+   ;; TODO: refactor
+   (list
+    (let (cscope-no-mouse-prompts)
+      ;; TODO: check for fboundp
+      (cscope-prompt-for-symbol "Find this egrep pattern " nil t t))))
+  (let ((project-root-dir (ac-php--get-project-root-dir)))
 
     (if (or ac-php-use-cscope-flag
-            (ac-php--get-use-cscope-from-config-file project-root-dir   ))
+            (ac-php--get-use-cscope-from-config-file project-root-dir))
         (progn
-          (setq cscope-initial-directory  (ac-php--get-tags-save-dir  project-root-dir  )  )
-          (cscope-find-egrep-pattern symbol)
-          )
-      (message "need  config: %s -> use-cscope:true" ac-php-config-file)
-    )))
+          (when (boundp 'cscope-initial-directory)
+            (setq cscope-initial-directory
+                  (ac-php--get-tags-save-dir project-root-dir)))
+          (when (fboundp 'cscope-find-egrep-pattern)
+            (cscope-find-egrep-pattern symbol)))
+      (message "need config: %s -> use-cscope:true" ac-php-config-file))))
 
 (defun ac-php-eldoc-documentation-function ()
   "A function to provide ElDoc support.


### PR DESCRIPTION
- Fixed assignment to free variable "function-item-len"
- Fixed reference to free variable "g-ac-php-tmp-tags"
- Fixed assignment to free variable "cscope-initial-directory"
- Fixed misspelling massge -> message
- Fixed misspelling prog -> progn
- Improved call "php-search-documentation" function
- Added xcscope dependency to be able call "cscope-prompt-for-symbol", "cscope-find-egrep-pattern", etc
- "previous-line" is for interactive use only replaced by "forward-line"
- Remove cl-related warnings
- Removed no longer needed "cl-defun" call