### PR TITLE
Fixed compilation warnings

### DIFF
--- a/Cask
+++ b/Cask
@@ -15,6 +15,7 @@
 (depends-on "popup" "0.5.0")
 (depends-on "dash" "1")
 (depends-on "xcscope" "1.0")
+
 ;; ac-php.el
 (depends-on "auto-complete" "1.4.0")
 (depends-on "yasnippet" "0.8.0")

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Prerequisite packages are:
   - [f][:melpa-f:]
   - [popup][:melpa-popup:]
   - [dash][:elpa-dash:]
-  - [xcscope][:melpa-xcscope:] (optional)
+  - [xcscope][:melpa-xcscope:]
   - [scope][:sf-cscope:] (optional)
 - **`ac-php.el`**
   - [auto-complete][:gh-ac:]

--- a/ac-php-core.el
+++ b/ac-php-core.el
@@ -81,11 +81,7 @@
 (require 'dash)
 (require 'eldoc)
 
-(eval-and-compile
-  (if (and (= emacs-major-version 24) (>= emacs-minor-version 4))
-      (require 'cl)))
-
-(require 'cl-lib) ; `cl-reduce'
+(require 'cl-lib) ; `cl-reduce', `cl-decf'
 
 ;;; Customization
 
@@ -388,18 +384,18 @@ ac-php developer only."
 
 (defun ac-php-location-stack-push ()
   (let ((bm (ac-php-current-location)))
-    (if  ( functionp  'xref-push-marker-stack)
+    (if  (functionp 'xref-push-marker-stack)
         (xref-push-marker-stack)
-      (ring-insert (with-no-warnings find-tag-marker-ring) (point-marker))
-      )
+      (ring-insert (with-no-warnings find-tag-marker-ring) (point-marker)))
     (while (> ac-php-location-stack-index 0)
-      (decf ac-php-location-stack-index)
+      (cl-decf ac-php-location-stack-index)
       (pop ac-php-location-stack))
     (unless (string= bm (nth 0 ac-php-location-stack))
       (push bm ac-php-location-stack)
-      (if (> (length ac-php-location-stack) ac-php-max-bookmark-count)
-          (nbutlast ac-php-location-stack (- (length ac-php-location-stack) ac-php-max-bookmark-count)))))
-  )
+      (when (> (length ac-php-location-stack) ac-php-max-bookmark-count)
+        (nbutlast ac-php-location-stack
+                  (- (length ac-php-location-stack)
+                     ac-php-max-bookmark-count))))))
 
 ;;function
 (defun ac-php-goto-line-col (line column)

--- a/ac-php.el
+++ b/ac-php.el
@@ -61,6 +61,9 @@
 (require 'ac-php-core)
 (require 'auto-complete)
 
+(defvar ac-php-template-start-point nil)
+(defvar ac-php-template-candidates (list "ok" "no" "yes:)"))
+
 (defface ac-php-candidate-face
   '((t (:background "lightgray" :foreground "navy")))
   "Face for php candidate"
@@ -99,11 +102,8 @@
         (setq access (get-text-property 0 'ac-php-access item))
         (setq from-class (get-text-property 0 'ac-php-from item))
         (if ( ac-php--tag-name-is-function item)
-            (setq doc (concat item  doc ")" ) )
-          (setq doc item )
-          )
-
-
+            (setq doc (concat item  doc ")"))
+          (setq doc item))
 
         (cond
          ( (or (string= tag-type "p") ( string= tag-type "m") ( string= tag-type "d")  )
@@ -111,9 +111,7 @@
          (return-type
           (format "%s  %s " return-type doc   ) )
          (t
-          doc))
-        ))
-  )
+          doc)))))
 
 (defun ac-php-action ()
   (interactive)
@@ -167,7 +165,6 @@
         (push item ss)))
     (setq ss (reverse ss) )
 
-
     (dolist (s ss)
       ;;return type
       (cond ((string-match "^\\([^(]*\\)(\\(.*)\\)" s)
@@ -191,10 +188,6 @@
           (t
            (message (replace-regexp-in-string "\n" "   ;    " help)))
           )))
-
-
-(defvar ac-php-template-start-point nil)
-(defvar ac-php-template-candidates (list "ok" "no" "yes:)"))
 
 (defun ac-php-template-candidate ()
   ac-php-template-candidates)
@@ -225,7 +218,6 @@
             (t
              (message "Dude! You are too out! Please install a yasnippet or a snippet script:)"))))))
 
-
 (defun ac-php-template-prefix ()
   ac-php-template-start-point)
 
@@ -241,7 +233,6 @@
   (ac-php-candidate )
     )
 
-
 (eval  '(ac-define-source php
           '((candidates . ac-php-candidate-ac )
             ;;(candidate-face . ac-php-candidate-face)
@@ -252,7 +243,6 @@
             (action . ac-php-action)
             (cache)
             (symbol . "p"))) )
-
 
 (eval  '(ac-define-source php-template
           '((candidates . ac-php-template-candidate)

--- a/ac-php.el
+++ b/ac-php.el
@@ -123,7 +123,12 @@
                 (get-text-property 0 'ac-php-help cur-item)))
          (raw-help (get-text-property 0 'ac-php-help cur-item ))
          (tag-type (get-text-property 0 'ac-php-tag-type cur-item))
-         (candidates (list)) ss fn args (ret-t "") ret-f)
+         (candidates (list))
+         ss
+         fn
+         args
+         (ret-t "")
+         ret-f)
 
     (when (ac-php--tag-name-is-function cur-item)
         (setq raw-help (concat  cur-item raw-help ")")))

--- a/company-php.el
+++ b/company-php.el
@@ -65,7 +65,9 @@ symbol is preceded by \"->\" or \"::\", ignoring
 
 If `company-begin-commands' is a list, it should include `c-electric-lt-gt'
 and `c-electric-colon', for automatic completion right after \">\" and
-\":\".")
+\":\"."
+  :group 'company-php
+  :type 'boolean)
 
 (defun company-ac-php-annotation (item)
   (let ((doc (ac-php-clean-document (get-text-property 0 'ac-php-help item))))
@@ -96,12 +98,11 @@ matches IDLE-BEGIN-AFTER-RE, return it wrapped in a cons."
             (cons symbol t)
           symbol)))))
 
-;; TODO it bad for namespace like \App\add\ss
+;; TODO: May not work for namespace like \App\add\ss
 (defun company-ac-php--prefix ()
   (if company-php-begin-after-member-access
-	  (company-ac-php-company-grab-symbol-cons "->\\|::" 2)
-	(company-ac-php--prefix-symbol)))
-
+      (company-ac-php-company-grab-symbol-cons "->\\|::" 2)
+    (company-ac-php--prefix-symbol)))
 
 (defun company-ac-php-candidate (arg)
   (let* ((ac-php-prefix-str (company-ac-php--prefix-symbol))

--- a/helm-ac-php-apropros.el
+++ b/helm-ac-php-apropros.el
@@ -45,6 +45,7 @@
 (require 'pcase)
 (require 'ac-php)
 (require 'helm)
+(require 'cl-lib)    ; `cl-equalp'
 
 (defun helm-ac-php--init ()
   (with-current-buffer (helm-candidate-buffer 'global)
@@ -52,7 +53,7 @@
      (lambda (k v)
        (mapc
         (lambda (v)
-          (when (not (equalp "sys" (aref v 3)))
+          (when (not (cl-equalp "sys" (aref v 3)))
             (insert
              (propertize
               (concat
@@ -69,26 +70,27 @@
      (ac-php-g--class-map (ac-php-get-tags-data)))
     (maphash
      (lambda (k v)
-       (when (not (equalp "sys" (aref v 3)))
+       (when (not (cl-equalp "sys" (aref v 3)))
          (insert
           (propertize
            (pcase (aref v 0)
-             ("d" (concat (if (equalp "void" (aref v 4)) "" (aref v 4)) (aref v 1)))
-             ("f" (concat (if (equalp "void" (aref v 4)) "" (aref v 4)) (substring (aref v 1) 0 (- (string-width (aref v 1)) 1))))
+             ("d" (concat (if (cl-equalp "void" (aref v 4)) "" (aref v 4)) (aref v 1)))
+             ("f" (concat (if (cl-equalp "void" (aref v 4)) "" (aref v 4)) (substring (aref v 1) 0 (- (string-width (aref v 1)) 1))))
              ("c" (aref v 1))
              ("i" (aref v 1)))
            'position (aref v 3)))
           (insert "\n")))
      (ac-php-g--function-map (ac-php-get-tags-data)))))
 
-(defun helm-ac-php--action (-candidate)
+(defun helm-ac-php--action ()
   (let* ((candidate (helm-get-selection nil 'withprop))
         (position (get-text-property 0 'position candidate)))
     (string-match "\\([0-9]+\\):\\([0-9]+\\)" position)
     (let ((file (match-string 1 position))
           (line (match-string 2 position)))
       (find-file (aref (ac-php-g--file-list (ac-php-get-tags-data)) (string-to-number file)))
-      (goto-line (string-to-number line)))))
+      (with-no-warnings
+        (goto-line (string-to-number line))))))
 
 (defvar helm-ac-php--source
   '((name . "Php apropos")


### PR DESCRIPTION
- Avoid a warning by using "cl-lib" instead of "cl"
-  Fixed assignment to free variable "ac-php-template-candidates"
-  Cleaned up ac-php, fixed "yas-expand-snippet" call (the function ‘yas-expand-snippet’ is not known to be defined)
- "company-php-begin-after-member-access" does not specify type. Fixed
- Fixed helm-ac-php-apropros warnings