### PR TITLE
Fix keyword completion due to a spurious comma

### DIFF
--- a/ac-php-core.el
+++ b/ac-php-core.el
@@ -267,7 +267,7 @@ Meant for `ac-php-mode-line-project-status'")
 (defvar ac-php--php-key-list '("public"
  "class" "namespace" "protected"
  "private" "function" "while"
- "extends" "return" "static", "global"))
+ "extends" "return" "static" "global"))
 
 (defvar ac-php-rebuild-tmp-error-msg nil)
 


### PR DESCRIPTION
The last commit broke keyword completion, causing errors like

`Company: backend company-ac-php-backend error "Wrong type argument: stringp, (\, "global")" with args (candidates g)`

This removes the extra comma that caused the issue.