### PR TITLE
Support phps-mode

### DIFF
--- a/company-php.el
+++ b/company-php.el
@@ -185,7 +185,9 @@ matches IDLE-BEGIN-AFTER-RE, return it wrapped in a cons."
   (interactive (list 'interactive))
   (cl-case command
     (interactive (company-begin-backend 'company-ac-php-backend))
-    (prefix (when (derived-mode-p 'php-mode) (company-ac-php--prefix)))
+    (prefix (when (or (equal major-mode 'phps-mode)
+		                  (equal major-mode 'php-mode))
+	            (company-ac-php--prefix)))
     (candidates (company-ac-php-candidate arg))
     (annotation (company-ac-php-annotation arg))
     (duplicates t)


### PR DESCRIPTION
Add support for [phps-mode](https://github.com/cjohansson/emacs-phps-mode), instead of check if the major mode is derived, check if there is one of the 2 php modes for Emacs.